### PR TITLE
feat: add Buffer polyfill to fix Vercel deployment

### DIFF
--- a/packages/dca-frontend/package.json
+++ b/packages/dca-frontend/package.json
@@ -33,6 +33,7 @@
     "@radix-ui/react-tooltip": "^1.1.8",
     "@tailwindcss/vite": "^4.0.14",
     "@tanstack/react-table": "^8.21.2",
+    "buffer": "^6.0.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "ethers": "^5.8.0",

--- a/packages/dca-frontend/src/App.tsx
+++ b/packages/dca-frontend/src/App.tsx
@@ -1,4 +1,6 @@
 import { useContext } from 'react';
+import { Buffer } from 'buffer';
+globalThis.Buffer = Buffer;
 
 import './App.css';
 

--- a/packages/dca-frontend/src/contexts/jwt.tsx
+++ b/packages/dca-frontend/src/contexts/jwt.tsx
@@ -66,7 +66,8 @@ export const JwtProvider: React.FC<JwtProviderProps> = ({ children }) => {
           logOut();
           return;
         }
-      } catch {
+      } catch (e) {
+        console.error('Error decoding JWT:', e);
         logOut();
         return;
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,9 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.21.2
         version: 8.21.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      buffer:
+        specifier: ^6.0.3
+        version: 6.0.3
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1


### PR DESCRIPTION
# Description

Vercel deployment was failing because the SDK was trying to use `Buffer` and it was not available in prod browser env (local dev was polyfilling this automatically)
This generated an issue where the FE would receive the jwt but crashed when trying to decode it right in the login process. As the fallback for that is to logout, we were not seeing an error. Therefore:
- Added Buffer polyfill for prod environment
- Added an error log in the login process, despite the logout fallback

Local reproduction with a prod build confirmed this
![Screenshot from 2025-04-10 18-52-56](https://github.com/user-attachments/assets/9c8b9ad1-47f2-4e00-885f-6ec45c718c13)
